### PR TITLE
We get a reference to a notification instead of ownership

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl ZWaveWatcher {
 }
 
 impl manager::NotificationWatcher for ZWaveWatcher {
-    fn on_notification(&self, notification: Notification) {
+    fn on_notification(&self, notification: &Notification) {
         //println!("Received notification: {:?}", notification);
 
         match notification.get_type() {


### PR DESCRIPTION
Goes with https://github.com/fxbox/openzwave-rust/pull/15
